### PR TITLE
Validate the PE file early on to raise errors

### DIFF
--- a/lib/msf/core/payload/windows/reflective_pe_loader.rb
+++ b/lib/msf/core/payload/windows/reflective_pe_loader.rb
@@ -20,9 +20,9 @@ start:                    ;
 	mov eax,[esi+0x3C]      ; Get the offset of "PE" to eax
 	mov ebx,[eax+esi+0x34]  ; Get the image base address to ebx
 	mov eax,[eax+esi+0x28]  ; Get the address of entry point to eax
-	push eax                ; Save the adress of entry to stack
+	push eax                ; Save the address of entry to stack
 	push 0x40               ; PAGE_EXECUTE_READ_WRITE
-	push 0x103000           ; MEM_COMMI | MEM_TOP_DOWN | MEM_RESERVE
+	push 0x103000           ; MEM_COMMIT | MEM_TOP_DOWN | MEM_RESERVE
 	push dword [esp+12]     ; dwSize
 	push 0x00               ; lpAddress
 	push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}         ; ror13( "kernel32.dll", "VirtualAlloc" )
@@ -140,7 +140,7 @@ complete:
 	pop eax                 ; Clean out the stack
 	pop edi
 	mov edx,edi             ; Copy the address of new base to EDX
-	pop eax                 ; Pop the addess_of_entry to EAX
+	pop eax                 ; Pop the address_of_entry to EAX
 	add edi,eax             ; Add the address of entry to new image base
 	pop ecx                 ; Pop the image_size to ECX
 memcpy:

--- a/lib/msf/core/payload/windows/x64/reflective_pe_loader.rb
+++ b/lib/msf/core/payload/windows/x64/reflective_pe_loader.rb
@@ -15,13 +15,13 @@ stub:
 	sub [rsp],rsi                   ; Subtract the address of pre mapped PE image and get the image_size to R11
 	call start                      ; Call start
 	#{asm_block_api}
-start:                              ;
+start:                            ;
 	pop rbp                         ; Get the address of hook_api to rbp
 	mov eax,dword [rsi+0x3C]        ; Get the offset of "PE" to eax
 	mov rbx,qword [rax+rsi+0x30]    ; Get the image base address to rbx
 	mov r12d,dword [rax+rsi+0x28]   ; Get the address of entry point to r12
 	mov r9d,0x40                    ; PAGE_EXECUTE_READ_WRITE
-	mov r8d,0x00103000              ; MEM_COMMI | MEM_TOP_DOWN | MEM_RESERVE
+	mov r8d,0x00103000              ; MEM_COMMIT | MEM_TOP_DOWN | MEM_RESERVE
 	mov rdx,[rsp]                   ; dwSize
 	xor rcx,rcx                     ; lpAddress
 	mov r10d,#{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}             ; hash( "kernel32.dll", "VirtualAlloc" )
@@ -118,7 +118,7 @@ LoadLibraryA:
 	mov r10d,#{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}             ; ror13( "kernel32.dll", "LoadLibraryA" )
 	call rbp                        ; LoadLibraryA([esp+4])
 	add rsp,32                      ; Fix the stack
-	pop rcx                         ; Retreive ecx
+	pop rcx                         ; Retrieve ecx
 	ret                             ; <-
 GetProcAddress:
 	mov rcx,r13                     ; Move the module handle to RCX as first parameter
@@ -144,7 +144,7 @@ CreateThread:
 	push rax                        ; lpThreadId
 	push rax                        ; dwCreationFlags
 	mov r9,rax                      ; lpParameter
-	mov r8,r13                      ; lpstartAddress
+	mov r8,r13                      ; lpStartAddress
  	mov rdx,rax                     ; dwStackSize
 	mov rcx,rax                     ; lpThreadAttributes
 	mov r10d,#{Rex::Text.block_api_hash('kernel32.dll', 'CreateThread')}             ; ror13( "kernel32.dll","CreateThread" )

--- a/modules/payloads/stages/windows/peinject.rb
+++ b/modules/payloads/stages/windows/peinject.rb
@@ -2,7 +2,9 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+#
 require 'msf/core/payload/windows/peinject'
+require 'msf/core/payload/windows/reflective_pe_loader'
 
 ###
 #

--- a/modules/payloads/stages/windows/x64/peinject.rb
+++ b/modules/payloads/stages/windows/x64/peinject.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core/payload/windows/peinject'
+require 'msf/core/payload/windows/x64/reflective_pe_loader'
 
 ###
 #


### PR DESCRIPTION
So while testing the MSF PR I ran into an issue where the PE I was trying to inject was missing relocation data causing the payload to fail silently. To address this I added and used `OptInjectablePE` which adds a validation method that is then called twice.

The first time it's called will prevent a handler from even starting if the PE is incompatible, this means the user won't have to wait for an incoming connection before realizing that they are trying to use an incompatible PE file and lose their opportunity 😢 .

The second is where the checks were originally, these were kept to avoid a TOCTOU issue and to ensure that the details are printed out so the user knows *why* the validation failed.

If validation fails on early usage with the new check, the user won't get a nice error message unfortunately due to where and how the validation takes place but I still this this is better than failing with information on what could be a live test, especially since you mention in the module info that the relocation data has to be present.


I also fixed some spelling mistakes in the ASM comments and switched to an `ensure` block to always close the connection.